### PR TITLE
cookie: add option to set samesite property

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 	flagSet.String("cookie-name", "_oauth2_proxy", "the name of the cookie that the oauth_proxy creates")
 	flagSet.String("cookie-secret", "", "the seed string for secure cookies (optionally base64 encoded)")
 	flagSet.String("cookie-domain", "", "an optional cookie domain to force cookies to (ie: .yourcompany.com)*")
+	flagSet.String("cookie-samesite", "None", "whether the cookie can be accessed by other domains (None, Lax or Strict)")
 	flagSet.Duration("cookie-expire", time.Duration(168)*time.Hour, "expire timeframe for cookie")
 	flagSet.Duration("cookie-refresh", time.Duration(0), "refresh the cookie after this duration; 0 to disable")
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -15,8 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bitly/oauth2_proxy/providers"
-	"github.com/bmizerany/assert"
 	"github.com/mbland/hmacauth"
 	"github.com/samsarahq/oauth2_proxy/providers"
 	"github.com/stretchr/testify/assert"
@@ -588,6 +586,14 @@ func TestProcessCookieNoCookieError(t *testing.T) {
 	if session != nil {
 		t.Errorf("expected nil session. got %#v", session)
 	}
+}
+
+func TestProcessCookieSameSiteSet(t *testing.T) {
+	pc_test := NewProcessCookieTestWithDefaults()
+	pc_test.proxy.CookieSameSite = http.SameSiteStrictMode
+
+	cookie := pc_test.MakeCookie("", time.Now())
+	assert.Equal(t, cookie.SameSite, http.SameSiteStrictMode)
 }
 
 func TestProcessCookieRefreshNotSet(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -102,7 +102,7 @@ func TestProxyURLsError(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 
 	expected := errorMsg([]string{
-		"error parsing upstream: parse 127.0.0.1:8081: " +
+		"error parsing upstream: parse \"127.0.0.1:8081\": " +
 			"first path segment in URL cannot contain colon"})
 	assert.Equal(t, expected, err.Error())
 }


### PR DESCRIPTION
SameSite lets you choose whether the cookie can be accessed by any domain or just the one specified by the cookie. https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1